### PR TITLE
ConcurrentModification e tempo de execução

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@
 # org.gradle.parallel=true
 GROUP=com.flipstudio.pluma
 ARTIFACT_ID=pluma
-VERSION=1.1.8
+VERSION=1.1.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@
 # org.gradle.parallel=true
 GROUP=com.flipstudio.pluma
 ARTIFACT_ID=pluma
-VERSION=1.1.6
+VERSION=1.1.8

--- a/pluma/src/main/java/com/flipstudio/pluma/Database.java
+++ b/pluma/src/main/java/com/flipstudio/pluma/Database.java
@@ -114,6 +114,7 @@ public final class Database {
 	}
 
 	public void execute(String sql) throws SQLiteException {
+		final long start = System.currentTimeMillis();
 		String[] errors = new String[1];
 
 		int rc = exec(mDB, sql, errors);
@@ -123,7 +124,7 @@ public final class Database {
 		}
 
 		if (mDatabaseListener != null) {
-			mDatabaseListener.onExecuteQuery(sql);
+			mDatabaseListener.onExecuteQuery(System.currentTimeMillis() - start, sql);
 		}
 	}
 
@@ -365,7 +366,7 @@ public final class Database {
 	//endregion
 
 	public interface DatabaseListener {
-		void onExecuteQuery(String query);
+		void onExecuteQuery(long timeExecution, String query);
 	}
 
 	public interface DatabaseIteractionListener {

--- a/pluma/src/main/java/com/flipstudio/pluma/Statement.java
+++ b/pluma/src/main/java/com/flipstudio/pluma/Statement.java
@@ -231,9 +231,14 @@ public final class Statement {
 	//endregion
 
 	public int step() {
-		if (!isBusy() && mDatabaseListener != null) mDatabaseListener.onExecuteQuery(getSQL());
+		final long start = System.currentTimeMillis();
+		final boolean canInvokeListener = !isBusy() && mDatabaseListener != null;
 
-		return step(mStmt);
+		int result = step(mStmt);
+
+		if (canInvokeListener) mDatabaseListener.onExecuteQuery(System.currentTimeMillis() - start, getSQL());
+
+		return result;
 	}
 
 	public boolean isBusy() {

--- a/pluma/src/main/java/com/flipstudio/pluma/Statement.java
+++ b/pluma/src/main/java/com/flipstudio/pluma/Statement.java
@@ -231,8 +231,10 @@ public final class Statement {
 	//endregion
 
 	public int step() {
-		final long start = System.currentTimeMillis();
-		final boolean canInvokeListener = !isBusy() && mDatabaseListener != null;
+		final boolean canInvokeListener = mDatabaseListener != null && !isBusy();
+
+		long start = 0;
+		if (canInvokeListener) start = System.currentTimeMillis();
 
 		int result = step(mStmt);
 

--- a/pluma/src/main/java/com/flipstudio/pluma/StatementCache.java
+++ b/pluma/src/main/java/com/flipstudio/pluma/StatementCache.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
  */
 public class StatementCache {
 	//region Fields
-	private static int MAX_CHACHED_STATEMENTS = 15;
+	private static int MAX_CACHED_STATEMENTS = 15;
 	private final Array<String> mQueriesCache;
 	private final HashMap<String, Statement> mStatementsCache;
 	final private Database mDatabase;
@@ -22,8 +22,8 @@ public class StatementCache {
 		if (database == null) throw new RuntimeException("Cannot create a StatementCache without a database");
 
 		mDatabase = database;
-		mStatementsCache = new HashMap<>(MAX_CHACHED_STATEMENTS);
-		mQueriesCache = new Array<>(MAX_CHACHED_STATEMENTS);
+		mStatementsCache = new HashMap<>(MAX_CACHED_STATEMENTS);
+		mQueriesCache = new Array<>(MAX_CACHED_STATEMENTS);
 	}
 	//endregion
 
@@ -35,7 +35,7 @@ public class StatementCache {
 				statement = mStatementsCache.get(query);
 
 				if (statement == null) {
-					if (mQueriesCache.size() == MAX_CHACHED_STATEMENTS) {
+					if (mQueriesCache.size() == MAX_CACHED_STATEMENTS) {
 						final String key = mQueriesCache.get(0);
 						mStatementsCache.get(key).close();
 						mStatementsCache.remove(key);

--- a/pluma/src/test/java/com/flipstudio/pluma/PlumaTests.java
+++ b/pluma/src/test/java/com/flipstudio/pluma/PlumaTests.java
@@ -44,7 +44,7 @@ public class PlumaTests {
 						+ "INSERT INTO people (name,lastName,birth) VALUES ('Reese','Kalia','763347737');");
 
 		mDatabase.setDatabaseListener(new Database.DatabaseListener() {
-			@Override public void onExecuteQuery(String query) {
+			@Override public void onExecuteQuery(long timeExecution, String query) {
 				recordQuery(query);
 			}
 		});
@@ -105,6 +105,8 @@ public class PlumaTests {
 		assertEquals("Unexpected person last name.", "Kalia", people.get(2).get("lastName"));
 		assertEquals("Unexpected person birth.", new Date(763347737000L), people.get(2).get("birth"));
 
+		rs.close();
+
 		rs = mDatabase.executeQuery("SELECT id, name FROM people WHERE id = ?", 2);
 		assertEquals("Unexpected column count.", 2, rs.getColumnCount());
 		if (rs.next()) {
@@ -112,9 +114,10 @@ public class PlumaTests {
 			assertEquals("Unexpected id.", 2, rs.getBigInteger(0).intValue());
 		}
 
-		Map<String, Object> args = new TreeMap<String, Object>();
+		Map<String, Object> args = new TreeMap<>();
 		args.put("FirstName", "Damon");
 
+		rs.close();
 		rs = mDatabase.executeQuery("SELECT id FROM people WHERE name = :FirstName", args);
 		if (rs.next()) {
 			assertEquals("Unexpected id.", 2, rs.getInt(0));
@@ -124,6 +127,7 @@ public class PlumaTests {
 				"SELECT id, name, lastName, birth FROM people",
 				"SELECT id, name FROM people WHERE id = ?",
 				"SELECT id FROM people WHERE name = :FirstName");
+		rs.close();
 	}
 	//endregion
 


### PR DESCRIPTION
* Agora podemos saber quanto tempo durou a execução de cada query

* Podia acontecer uma concurrentModification no cache de statement, aí fiz o método ser syncronized e ja troquei o dicionário ordenado pelo array com hashMap(normal). Aí ja pude implementar a nova funcionalidade que faz com que quando tu busque um statement na cache, ele jogue esse statement "pra cima" de novo